### PR TITLE
small bug understimating count in kcount

### DIFF
--- a/k_seek.pl
+++ b/k_seek.pl
@@ -276,9 +276,12 @@ sub degen {
 	my $diff = length($target) - length($kmer2);
 	if ($diff == 0) {
 		# find substitutions
-		foreach (0 .. (1 - length($kmer2))) {
-			my $degen_kmer = substr($kmer2, $_, 1, "[ACTGN]");
-			if ($target =~ /$degen_kmer/g) {
+		# kmer length is positive doing 1 - bigger than one yield a negative number
+		foreach (0 .. ( length($kmer2) - 1)) {
+			# unfortunalty the subtr function return the exised string not the new string and in fact modify the original string
+			my $temp_k = $kmer2; # make a copy copy
+			my $degen_kmer = substr($temp_k, $_, 1, "[ACTGN]"); 
+			if ($target =~ /$temp_k/g) {
 				return 1;
 			}
 		} 


### PR DESCRIPTION
the detection of substitution in degen was non working. two bugs were present. First the loop start with foreach (0 .. ( 1- length($kmer2) )) will yield a negative number and does not loop. -> changed to foreach (0 .. ( length($kmer2) -1 ))

Secondly, the string substitution was problematic
`my $degen_kmer = substr($kmer2, $_, 1, "[ACTGN]"); `
this line modify 2 variable
$degen_kmer is assigned to the excised base
and $kmer2 is modified in place
a solution is to make a copy of the kmer at each loop to modify the copy in place and use it in the regexp.

I tested this solution on a couple of read.